### PR TITLE
Fixing multiple build errors by including <algorithm> in DaxaCore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,8 @@ FodyWeavers.xsd
 
 .vscode
 _out
+
+# CLion IDE and build directories
+.idea
+cmake-build*
+vcpkg_installed

--- a/Daxa/include/Daxa/DaxaCore.hpp
+++ b/Daxa/include/Daxa/DaxaCore.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <memory>
 #include <cmath>
+#include <algorithm>
 
 using u64 = uint64_t;
 using i64 = int64_t;


### PR DESCRIPTION
Under GCC in Linux, I was getting a number of compile errors across different source files for things like std::find_if and std::clamp, which are included in the algorithm header, but the algorithm header isn't #included anywhere apparently.

By adding the include in DaxaCore, all compile errors were resolved.

Also appended some build and IDE junk to the .gitignore.