### PR TITLE
Fix build error

### DIFF
--- a/src/impl_pipeline.cpp
+++ b/src/impl_pipeline.cpp
@@ -1,6 +1,7 @@
 #include "impl_pipeline.hpp"
 #include "impl_swapchain.hpp"
 #include "impl_device.hpp"
+#include <iostream>
 
 static constexpr TBuiltInResource DAXA_DEFAULT_BUILTIN_RESOURCE = {
     .maxLights = 32,


### PR DESCRIPTION
Fixes `impl_pipeline.cpp:899:22: error: no member named 'cerr' in namespace 'std'`