### PR TITLE
Add upload task back to hello daxa triangle sample.

### DIFF
--- a/tests/4_hello_daxa/2_triangle/main.cpp
+++ b/tests/4_hello_daxa/2_triangle/main.cpp
@@ -303,32 +303,6 @@ void upload_vertex_data(daxa::Device & device, daxa::BufferId buffer_id)
         .debug_name = "my upload task",
     });
 
-    // bool cond = false;
-    // temp_task_list.conditional({
-    //     .condition = &cond,
-    //     .when_true = [&](){
-    //         temp_task_list.set_initial_access(task_buffer_id, access);
-    //         temp_task_list.add_task({});
-    //         temp_task_list.add_task({});
-    //         temp_task_list.add_task({});
-    //         temp_task_list.conditional({
-    //             .condition = &cond,
-    //             .when_true = [&](){
-    //                 temp_task_list.set_initial_access(task_buffer_id, access);
-    //                 temp_task_list.add_task({});
-    //                 temp_task_list.add_task({});
-    //                 temp_task_list.add_task({});
-    //             },
-    //             .when_false = [&](){
-    //                 temp_task_list.set_initial_access(task_buffer_id, access2);
-    //             },
-    //         });
-    //     },
-    //     .when_false = [&](){
-    //         temp_task_list.set_initial_access(task_buffer_id, access2);
-    //     },
-    // });
-
     // We'll now just create a dummy task which dictates to the Task Runtime
     // that there must be a memory barrier after this task.
     temp_task_list.add_task({

--- a/tests/4_hello_daxa/2_triangle/main.cpp
+++ b/tests/4_hello_daxa/2_triangle/main.cpp
@@ -279,6 +279,29 @@ void upload_vertex_data(daxa::Device & device, daxa::BufferId buffer_id)
 
     auto task_buffer_id = temp_task_list.create_task_buffer({.debug_name = "my task buffer"});
     temp_task_list.add_runtime_buffer(task_buffer_id, buffer_id);
+	
+    // We'll first make a task to update the buffer
+    temp_task_list.add_task({
+        .used_buffers = {
+            // Since this task is going to copy a staging buffer to the
+            // actual buffer, we'll say that this task uses the buffer
+            // with a transfer write operation!
+            {task_buffer_id, daxa::TaskBufferAccess::TRANSFER_WRITE},
+        },
+        .task = [task_buffer_id](daxa::TaskRuntimeInterface task_runtime)
+        {
+            auto cmd_list = task_runtime.get_command_list();
+
+            // see upload_vertex_data_task(...) for more info on the
+            // uploading of the data itself.
+
+            // We'll call upload_vertex_data_task(...) with the buffer ID,
+            // which we can query from the task runtime.
+
+            upload_vertex_data_task(task_runtime.get_device(), cmd_list, task_runtime.get_buffers(task_buffer_id)[0]);
+        },
+        .debug_name = "my upload task",
+    });
 
     // bool cond = false;
     // temp_task_list.conditional({


### PR DESCRIPTION
The included block of code is necessary for uploading vertex data to the vertex buffer. Principally, it creates a task in the temporary task list in the function `upload_vertex_data` which calls `upload_vertex_data_task`.