### PR TITLE
Compilation fixes on GCC.

### DIFF
--- a/include/daxa/c/device.h
+++ b/include/daxa/c/device.h
@@ -172,7 +172,7 @@ static const daxa_DeviceInfo DAXA_DEFAULT_DEVICE_INFO = {
     .max_allowed_images = 10000,
     .max_allowed_buffers = 10000,
     .max_allowed_samplers = 400,
-    .name = {.data = {}, .size = 0},
+    .name = {.data = NULL, .size = 0},
 };
 
 typedef struct
@@ -257,7 +257,7 @@ daxa_dvc_destroy_sampler(daxa_Device device, daxa_SamplerId sampler);
 
 DAXA_EXPORT daxa_Result
 daxa_dvc_info_buffer(daxa_Device device, daxa_BufferId buffer, daxa_BufferInfo * out_info);
-DAXA_EXPORT  daxa_Result
+DAXA_EXPORT daxa_Result
 daxa_dvc_info_image(daxa_Device device, daxa_ImageId image, daxa_ImageInfo * out_info);
 DAXA_EXPORT daxa_Result
 daxa_dvc_info_image_view(daxa_Device device, daxa_ImageViewId id, daxa_ImageViewInfo * out_info);

--- a/include/daxa/c/gpu_resources.h
+++ b/include/daxa/c/gpu_resources.h
@@ -1,6 +1,7 @@
 #ifndef __DAXA_GPU_RESOURCES_H__
 #define __DAXA_GPU_RESOURCES_H__
 
+#include "types.h"
 #include <vk_mem_alloc.h>
 
 #include <daxa/c/types.h>
@@ -104,7 +105,7 @@ typedef struct
 
 static const daxa_BufferInfo DAXA_DEFAULT_BUFFER_INFO = {
     .size = 0,
-    .allocate_info = {},
+    .allocate_info = DAXA_MEMORY_FLAG_NONE,
     .name = {.data = {}, .size = 0},
 };
 static const daxa_ImageInfo DAXA_DEFAULT_IMAGE_INFO = {
@@ -116,7 +117,7 @@ static const daxa_ImageInfo DAXA_DEFAULT_IMAGE_INFO = {
     .array_layer_count = 1,
     .sample_count = 1,
     .usage = 0,
-    .allocate_info = {},
+    .allocate_info = DAXA_MEMORY_FLAG_NONE,
     .name = {.data = {}, .size = 0},
 };
 static const daxa_ImageViewInfo DAXA_DEFAULT_IMAGE_VIEW_INFO = {

--- a/src/impl_core.cpp
+++ b/src/impl_core.cpp
@@ -63,7 +63,7 @@ auto make_subresource_layers(ImageArraySlice const & slice, VkImageAspectFlags a
 }
 auto create_surface(daxa_Instance instance, daxa_NativeWindowHandle handle, [[maybe_unused]] daxa_NativeWindowPlatform platform, VkSurfaceKHR * out_surface) -> daxa_Result
 {
-    #if defined(_WIN32)
+#if defined(_WIN32)
     VkWin32SurfaceCreateInfoKHR const surface_ci{
         .sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR,
         .pNext = nullptr,
@@ -77,7 +77,7 @@ auto create_surface(daxa_Instance instance, daxa_NativeWindowHandle handle, [[ma
         return std::bit_cast<daxa_Result>(vk_result);
     }
 #elif defined(__linux__)
-    switch (platform)
+    switch (std::bit_cast<daxa::NativeWindowPlatform>(platform))
     {
 #if DAXA_BUILT_WITH_WAYLAND
     case NativeWindowPlatform::WAYLAND_API:


### PR DESCRIPTION
Fixes issues when building for linux with GCC as compiler on X11.
  gcc fails compile with `error: scalar initializer cannot be empty`
  thus replacing with the correct initializers.
Also corrects indents and whitespaces in some locations.