### PR TITLE
Change daxa::None to daxa::Nothing to prevent collision with X.h

### DIFF
--- a/include/daxa/types.hpp
+++ b/include/daxa/types.hpp
@@ -98,7 +98,7 @@ namespace daxa
     };
 
     struct NoneT { };
-    static inline constexpr NoneT None = NoneT{};
+    static inline constexpr NoneT Nothing = NoneT{};
 
     template <typename T>
     struct Optional

--- a/tests/2_daxa_api/11_mesh_shader/main.cpp
+++ b/tests/2_daxa_api/11_mesh_shader/main.cpp
@@ -150,7 +150,7 @@ auto main() -> int
                 .compile_options = daxa::ShaderCompileOptions{.entry_point = "entry_fragment"},
             },
             .color_attachments = {{.format = swapchain.get_format()}},
-            .raster = {.static_state_sample_count = daxa::None},
+            .raster = {.static_state_sample_count = daxa::Nothing},
             // .push_constant_size = sizeof(DrawTri::attachment_shader_blob_size()),
             .name = "my pipeline",
         });


### PR DESCRIPTION
I fixed Daxa compiling on Linux with X11 by changing daxa::None to daxa::Nothing