### PR TITLE
Fix missing header <algorithm> for std::sort

### DIFF
--- a/src/impl_instance.cpp
+++ b/src/impl_instance.cpp
@@ -3,6 +3,7 @@
 #include "impl_device.hpp"
 #include "impl_features.hpp"
 
+#include <algorithm>
 #include <vector>
 
 // --- Begin API Functions ---


### PR DESCRIPTION
Hi, all

I am the maintainer of vcpkg. I found an issue in our latest vs preview ([Visual Studio 2022 v17.12](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes-preview?tabs=allfeatures)) test.

I think the change here is by design, it only needs to add a header file. You will easily reproduce this problem locally.

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\functional(31): note: see declaration of 'std'
D:/b/daxa/src/3.0.2-e19dccb089.clean/src/impl_instance.cpp(194): error C3861: 'sort': identifier not found
```

The issue occurred when trying to use `std::sort` without including the necessary `<algorithm>` header file. This PR adds the required include to ensure proper compilation. 

And I also submitted a PR https://github.com/microsoft/vcpkg/pull/41461 to vcpkg to pay attention to this issue. :)

Thanks,
Frank

