### PR TITLE
Proposal: Allow for a user-defined header file to be included at the start of daxa/core.hpp

### DIFF
--- a/include/daxa/core.hpp
+++ b/include/daxa/core.hpp
@@ -4,57 +4,44 @@
 #include <optional>
 #include <string>
 
-#if !defined(DAXA_VALIDATION)
-#if defined(NDEBUG)
-#define DAXA_VALIDATION 0
-#else
-#define DAXA_VALIDATION 1
-#endif
-#endif
-
-#if DAXA_VALIDATION
-#include <iostream>
-#include <stdexcept>
-
-#define DAXA_GPU_ID_VALIDATION 1
-
-#define DAXA_DBG_ASSERT_FAIL_STRING "[[DAXA ASSERT FAILURE]]"
-
-#define DAXA_DBG_ASSERT_TRUE_M(x, m)                                              \
-    do                                                                            \
-    {                                                                             \
-        if (std::is_constant_evaluated())                                         \
-        {                                                                         \
-            /* how do we check this??? static_assert(x); */                       \
-        }                                                                         \
-        else if (!(x))                                                            \
-        {                                                                         \
-            std::cerr << DAXA_DBG_ASSERT_FAIL_STRING << ": " << (m) << std::endl; \
-            throw std::runtime_error("DAXA DEBUG ASSERTION FAILURE");             \
-        }                                                                         \
-    } while (false)
-#define DAXA_DBG_ASSERT_TRUE_MS(x, STREAM)                                        \
-    do                                                                            \
-    {                                                                             \
-        if (std::is_constant_evaluated())                                         \
-        {                                                                         \
-            /* how do we check this??? static_assert(x); */                       \
-        }                                                                         \
-        else if (!(x))                                                            \
-        {                                                                         \
-            std::cerr << DAXA_DBG_ASSERT_FAIL_STRING << ": " STREAM << std::endl; \
-            throw std::runtime_error("DAXA DEBUG ASSERTION FAILURE");             \
-        }                                                                         \
-    } while (false)
-#else
-
-#define DAXA_DBG_ASSERT_TRUE_M(x, m)
-#define DAXA_DBG_ASSERT_TRUE_MS(x, m)
-
+#if defined(DAXA_CORE_USER_DEFINED_H)
+#include DAXA_CORE_USER_DEFINED_H
 #endif
 
 #if !defined(DAXA_GPU_ID_VALIDATION)
+#if DAXA_VALIDATION
+#define DAXA_GPU_ID_VALIDATION 1
+#else
 #define DAXA_GPU_ID_VALIDATION 0
+#endif
+#endif
+
+#if !defined(DAXA_THROW_M)
+#include <iostream>
+#include <stdexcept>
+
+#define DAXA_THROW_M(e, m)                                        \
+    std::cerr << "[[DAXA ASSERT FAILURE]]: " << (m) << std::endl; \
+    throw std::runtime_error(e)
+#endif
+
+#if !defined(DAXA_DBG_ASSERT_TRUE_M)
+#if DAXA_VALIDATION
+#define DAXA_DBG_ASSERT_TRUE_M(x, m)                         \
+    do                                                       \
+    {                                                        \
+        if (std::is_constant_evaluated())                    \
+        {                                                    \
+            /* how do we check this??? static_assert(x); */  \
+        }                                                    \
+        else if (!(x))                                       \
+        {                                                    \
+            DAXA_THROW_M("DAXA DEBUG ASSERTION FAILURE", m); \
+        }                                                    \
+    } while (false)
+#else
+#define DAXA_DBG_ASSERT_TRUE_M(x, m)
+#endif
 #endif
 
 namespace daxa

--- a/include/daxa/core.hpp
+++ b/include/daxa/core.hpp
@@ -8,6 +8,14 @@
 #include DAXA_CORE_USER_DEFINED_H
 #endif
 
+#if !defined(DAXA_VALIDATION)
+#if defined(NDEBUG)
+#define DAXA_VALIDATION 0
+#else
+#define DAXA_VALIDATION 1
+#endif
+#endif
+
 #if !defined(DAXA_GPU_ID_VALIDATION)
 #if DAXA_VALIDATION
 #define DAXA_GPU_ID_VALIDATION 1

--- a/src/cpp_wrapper.cpp
+++ b/src/cpp_wrapper.cpp
@@ -4,7 +4,6 @@
 #include <daxa/daxa.hpp>
 
 #include <chrono>
-#include <iostream>
 #include <utility>
 #include <format>
 #include <bit>
@@ -151,15 +150,12 @@ void check_result(daxa_Result result, char const * message, std::array<daxa_Resu
     }
     if (!result_allowed)
     {
-#if DAXA_VALIDATION
-        std::cout << std::format(
-                         "[[DAXA ASSERT FAILURE]]: error code: {}({}), {}.\n\n",
-                         daxa_result_to_string(result),
-                         std::bit_cast<i32>(result),
-                         message)
-                  << std::flush;
-#endif
-        throw std::runtime_error({});
+        DAXA_THROW_M("", std::format(
+                             "[[DAXA ASSERT FAILURE]]: error code: {}({}), {}.\n\n",
+                             daxa_result_to_string(result),
+                             std::bit_cast<i32>(result),
+                             message)
+                             .c_str());
     }
 }
 
@@ -463,9 +459,7 @@ namespace daxa
     {
         if (info.queue_family != daxa::QueueFamily::MAIN)
         {
-            std::cout << "[[DAXA ASSERT FAILURE]]: queue family must be main for a generic command recorder.\n\n"
-                      << std::flush;
-            throw std::runtime_error({});
+            DAXA_THROW_M("", "queue family must be main for a generic command recorder.\n\n");
         }
         CommandRecorder ret = {};
         check_result(daxa_dvc_create_command_recorder(
@@ -480,9 +474,7 @@ namespace daxa
     {
         if (info.queue_family != daxa::QueueFamily::MAIN && info.queue_family != daxa::QueueFamily::COMPUTE)
         {
-            std::cout << "[[DAXA ASSERT FAILURE]]: queue family must be either main or compute for a compute command recorder.\n\n"
-                      << std::flush;
-            throw std::runtime_error({});
+            DAXA_THROW_M("", "queue family must be either main or compute for a compute command recorder.\n\n");
         }
         ComputeCommandRecorder ret = {};
         check_result(daxa_dvc_create_command_recorder(

--- a/src/impl_core.hpp
+++ b/src/impl_core.hpp
@@ -14,14 +14,6 @@
 #include <memory>
 #include <format>
 
-#if DAXA_VALIDATION
-#include <iostream>
-#include <cstdlib>
-#include <stdexcept>
-
-#define DAXA_GPU_ID_VALIDATION 1
-#endif
-
 #if defined(_WIN32)
 #define VK_USE_PLATFORM_WIN32_KHR
 #define WIN32_LEAN_AND_MEAN

--- a/src/utils/impl_task_graph.cpp
+++ b/src/utils/impl_task_graph.cpp
@@ -1028,24 +1028,20 @@ namespace daxa
         DAXA_DBG_ASSERT_TRUE_M(!id.is_empty(), "Detected empty task image id. Please make sure to only use initialized task image ids.");
         if (id.is_persistent())
         {
-            DAXA_DBG_ASSERT_TRUE_MS(
+            DAXA_DBG_ASSERT_TRUE_M(
                 persistent_image_index_to_local_index.contains(id.index),
-                << "Detected invalid access of persistent task image id "
-                << id.index
-                << " in task graph \""
-                << info.name
-                << "\". Please make sure to declare persistent resource use to each task graph that uses this image with the function use_persistent_image!");
+                std::format("Detected invalid access of persistent task image id {} in task graph \"{}\". "
+                            "Please make sure to declare persistent resource use to each task graph that uses this image with the function use_persistent_image!",
+                            id.index, info.name).c_str());
             return TaskImageView{{.task_graph_index = this->unique_index, .index = persistent_image_index_to_local_index.at(id.index)}, id.slice};
         }
         else
         {
-            DAXA_DBG_ASSERT_TRUE_MS(
+            DAXA_DBG_ASSERT_TRUE_M(
                 id.task_graph_index == this->unique_index,
-                << "Detected invalid access of transient task image id "
-                << (id.index)
-                << " in task graph \""
-                << info.name
-                << "\". Please make sure that you only use transient image within the list they are created in!");
+                std::format("Detected invalid access of transient task image id {} in task graph \"{}\". "
+                            "Please make sure that you only use transient image within the list they are created in!",
+                            id.index, info.name).c_str());
             return TaskImageView{{.task_graph_index = this->unique_index, .index = id.index}, id.slice};
         }
     }


### PR DESCRIPTION
This makes it possible for a user provided header file (`DAXA_CORE_USER_DEFINED_H`) to be `#include`d at the start of core.hpp.

Paired with `DAXA_THROW_M`, it allows for exceptions to be handled in other ways (e.g. using `std::abort` instead of `throw`), and `<stdexcept>` is no longer required.

`DAXA_DBG_ASSERT_TRUE_MS` is also removed, making `<iostream>` optional as well (which has the benefit of decreasing compile times).

FYI: this is similar to VMA's `VMA_CONFIGURATION_USER_INCLUDES_H` and Dear ImGui's `IMGUI_INCLUDE_IMGUI_USER_H / IMGUI_USER_H_FILENAME`.