### PR TITLE
Expose VkColorSpaceKHR through daxa's Swapchain

### DIFF
--- a/include/daxa/c/swapchain.h
+++ b/include/daxa/c/swapchain.h
@@ -39,6 +39,8 @@ DAXA_EXPORT VkExtent2D
 daxa_swp_get_surface_extent(daxa_Swapchain swapchain);
 DAXA_EXPORT VkFormat
 daxa_swp_get_format(daxa_Swapchain swapchain);
+DAXA_EXPORT VkColorSpaceKHR
+daxa_swp_get_color_space(daxa_Swapchain swapchain);
 DAXA_EXPORT DAXA_NO_DISCARD daxa_Result
 daxa_swp_resize(daxa_Swapchain swapchain);
 DAXA_EXPORT DAXA_NO_DISCARD daxa_Result

--- a/include/daxa/swapchain.hpp
+++ b/include/daxa/swapchain.hpp
@@ -96,6 +96,7 @@ namespace daxa
         [[nodiscard]] auto info() const -> SwapchainInfo const &;
         [[nodiscard]] auto get_surface_extent() const -> Extent2D;
         [[nodiscard]] auto get_format() const -> Format;
+        [[nodiscard]] auto get_color_space() const -> ColorSpace;
 
       protected:
         template <typename T, typename H_T>

--- a/include/daxa/types.hpp
+++ b/include/daxa/types.hpp
@@ -1337,11 +1337,11 @@ namespace daxa
         ADOBERGB_NONLINEAR = 1000104012,
         PASS_THROUGH = 1000104013,
         EXTENDED_SRGB_NONLINEAR = 1000104014,
-        DISPLAY_NATIVE = 1000213000,
-        RGB_NONLINEAR = EXTENDED_SRGB_NONLINEAR,
-        DCI_P3_LINEAR = DISPLAY_P3_LINEAR,
+        DISPLAY_NATIVE_AMD = 1000213000,
         MAX_ENUM = 0x7fffffff,
     };
+
+    [[nodiscard]] auto to_string(ColorSpace color_space) -> std::string_view;
 
     enum struct ImageLayout
     {

--- a/src/cpp_wrapper.cpp
+++ b/src/cpp_wrapper.cpp
@@ -839,6 +839,11 @@ namespace daxa
         return std::bit_cast<Format>(daxa_swp_get_format(rc_cast<daxa_Swapchain>(this->object)));
     }
 
+    auto Swapchain::get_color_space() const -> ColorSpace
+    {
+        return std::bit_cast<ColorSpace>(daxa_swp_get_color_space(rc_cast<daxa_Swapchain>(this->object)));
+    }
+
     auto Swapchain::inc_refcnt(ImplHandle const * object) -> u64
     {
         return daxa_swp_inc_refcnt(rc_cast<daxa_Swapchain>(object));
@@ -1593,6 +1598,30 @@ namespace daxa
         case Format::PVRTC1_4BPP_SRGB_BLOCK_IMG: return "PVRTC1_4BPP_SRGB_BLOCK_IMG";
         case Format::PVRTC2_2BPP_SRGB_BLOCK_IMG: return "PVRTC2_2BPP_SRGB_BLOCK_IMG";
         case Format::PVRTC2_4BPP_SRGB_BLOCK_IMG: return "PVRTC2_4BPP_SRGB_BLOCK_IMG";
+        default: return "unknown";
+        }
+    }
+
+    auto to_string(ColorSpace color_space) -> std::string_view
+    {
+        switch (color_space)
+        {
+        case ColorSpace::SRGB_NONLINEAR: return "SRGB_NONLINEAR";
+        case ColorSpace::DISPLAY_P3_NONLINEAR: return "DISPLAY_P3_NONLINEAR";
+        case ColorSpace::EXTENDED_SRGB_LINEAR: return "EXTENDED_SRGB_LINEAR";
+        case ColorSpace::DISPLAY_P3_LINEAR: return "DISPLAY_P3_LINEAR";
+        case ColorSpace::DCI_P3_NONLINEAR: return "DCI_P3_NONLINEAR";
+        case ColorSpace::BT709_LINEAR: return "BT709_LINEAR";
+        case ColorSpace::BT709_NONLINEAR: return "BT709_NONLINEAR";
+        case ColorSpace::BT2020_LINEAR: return "BT2020_LINEAR";
+        case ColorSpace::HDR10_ST2084: return "HDR10_ST2084";
+        case ColorSpace::DOLBYVISION: return "DOLBYVISION";
+        case ColorSpace::HDR10_HLG: return "HDR10_HLG";
+        case ColorSpace::ADOBERGB_LINEAR: return "ADOBERGB_LINEAR";
+        case ColorSpace::ADOBERGB_NONLINEAR: return "ADOBERGB_NONLINEAR";
+        case ColorSpace::PASS_THROUGH: return "PASS_THROUGH";
+        case ColorSpace::EXTENDED_SRGB_NONLINEAR: return "EXTENDED_SRGB_NONLINEAR";
+        case ColorSpace::DISPLAY_NATIVE_AMD: return "DISPLAY_NATIVE_AMD";
         default: return "unknown";
         }
     }

--- a/src/impl_swapchain.cpp
+++ b/src/impl_swapchain.cpp
@@ -157,6 +157,11 @@ auto daxa_swp_get_format(daxa_Swapchain self) -> VkFormat
     return self->vk_surface_format.format;
 }
 
+auto daxa_swp_get_color_space(daxa_Swapchain self) -> VkColorSpaceKHR
+{
+    return self->vk_surface_format.colorSpace;
+}
+
 auto daxa_swp_resize(daxa_Swapchain self) -> daxa_Result
 {
     auto result = self->recreate();

--- a/tests/2_daxa_api/5_swapchain/main.cpp
+++ b/tests/2_daxa_api/5_swapchain/main.cpp
@@ -18,7 +18,12 @@ namespace tests
                 .name = ("swapchain (simple_creation)"),
             });
 
-            App() : AppWindow<App>(" (simple_creation)") {}
+            App() : AppWindow<App>(" (simple_creation)")
+            {
+                [[maybe_unused]] daxa::Extent2D surface_extent = swapchain.get_surface_extent();
+                [[maybe_unused]] daxa::Format format = swapchain.get_format();
+                [[maybe_unused]] daxa::ColorSpace color_space = swapchain.get_color_space();
+            }
 
             void on_mouse_move(f32 /*unused*/, f32 /*unused*/) {}
             void on_mouse_button(i32 /*unused*/, i32 /*unused*/) {}


### PR DESCRIPTION
Additionally, I have:
1. Updated `tests/2_daxa_api/5_swapchain/main.cpp` to show an example of the swapchain's "getter" functions (mostly to show everything compiles; I could remove this if preferred);
2. Removed `RGB_NONLINEAR` as it doesn't reflect any value from https://registry.khronos.org/vulkan/specs/latest/man/html/VkColorSpaceKHR.html
3. Removed the deprecated `DCI_P3_LINEAR` (it's already covered by `DISPLAY_P3_LINEAR`);
4. Renamed `DISPLAY_NATIVE` to `DISPLAY_NATIVE_AMD` to make it clear that it comes from an AMD-specific extension (it's neither _KHR nor _EXT).