### PR TITLE
Proposal: Add DAXA_REMOVE_DEPRECATED to exclude [[deprecated]] C++ API

### DIFF
--- a/include/daxa/core.hpp
+++ b/include/daxa/core.hpp
@@ -57,6 +57,10 @@
 #define DAXA_GPU_ID_VALIDATION 0
 #endif
 
+#if !defined(DAXA_REMOVE_DEPRECATED)
+#define DAXA_REMOVE_DEPRECATED 1
+#endif
+
 namespace daxa
 {
     /// @brief  A platform-dependent window resource.

--- a/include/daxa/device.hpp
+++ b/include/daxa/device.hpp
@@ -195,6 +195,7 @@ namespace daxa
         u32 invocation_reorder_mode = {};
     };
 
+#if !DAXA_REMOVE_DEPRECATED
     struct DeviceFlagsProperties
     {
         using Data = u32;
@@ -216,6 +217,7 @@ namespace daxa
         [[deprecated("Use ExplicitFeatureFlags or ImplicitFeatureFlags instead")]] static inline constexpr DeviceFlags DYNAMIC_STATE_3 = {0x1 << 11};
         [[deprecated("Use ExplicitFeatureFlags or ImplicitFeatureFlags instead")]] static inline constexpr DeviceFlags SHADER_ATOMIC_FLOAT = {0x1 << 12};
     };
+#endif
 
     enum struct MissingRequiredVkFeature
     {
@@ -320,6 +322,7 @@ namespace daxa
         MissingRequiredVkFeature missing_required_feature;
     };
 
+#if !DAXA_REMOVE_DEPRECATED
     [[deprecated("Use create_device_2 and Instance::choose_device instead")]] DAXA_EXPORT_CXX auto default_device_score(DeviceProperties const & device_props) -> i32;
 
     struct [[deprecated("Use DeviceInfo2 instead")]] DeviceInfo
@@ -337,6 +340,7 @@ namespace daxa
         u32 max_allowed_acceleration_structures = 10'000;
         SmallString name = {};
     };
+#endif
 
     struct DeviceInfo2
     {
@@ -578,6 +582,7 @@ namespace daxa
         [[nodiscard]] auto properties() const -> DeviceProperties const &;
         [[nodiscard]] auto get_supported_present_modes(NativeWindowHandle native_handle, NativeWindowPlatform native_platform) const -> std::vector<PresentMode>;
 
+#if !DAXA_REMOVE_DEPRECATED
         /// DEPRECATED:
 
         [[deprecated("Use tlas_build_sizes or as_build_sizes Instead")]] [[nodiscard]] auto get_tlas_build_sizes(TlasBuildInfo const & info) { return tlas_build_sizes(info); }
@@ -601,6 +606,7 @@ namespace daxa
         [[deprecated("Use buffer_device_address or device_address instead")]] [[nodiscard]] auto get_device_address(BufferId id) const { return buffer_device_address(id); }
         [[deprecated("Use blas_device_address or device_address instead")]] [[nodiscard]] auto get_device_address(BlasId id) const { return blas_device_address(id); }
         [[deprecated("Use tlas_device_address or device_address instead")]] [[nodiscard]] auto get_device_address(TlasId id) const { return tlas_device_address(id); }
+#endif
 
       protected:
         template <typename T, typename H_T>

--- a/include/daxa/instance.hpp
+++ b/include/daxa/instance.hpp
@@ -30,12 +30,14 @@ namespace daxa
     {
         Instance() = default;
 
+#if !DAXA_REMOVE_DEPRECATED
         [[deprecated("Use create_device_2 instead")]] [[nodiscard]] auto create_device(DeviceInfo const & device_info) -> Device;
+#endif
         [[nodiscard]] auto create_device_2(DeviceInfo2 const & device_info) -> Device;
 
         /// Convenience function to pick a physical device.
         /// Picks first supported device that satisfies the given device info and desired implicit features.
-        auto choose_device(ImplicitFeatureFlags desired_features, DeviceInfo2 const& base_info) -> DeviceInfo2;
+        auto choose_device(ImplicitFeatureFlags desired_features, DeviceInfo2 const & base_info) -> DeviceInfo2;
 
         auto list_devices_properties() -> std::span<DeviceProperties const>;
 

--- a/include/daxa/utils/task_graph_types.hpp
+++ b/include/daxa/utils/task_graph_types.hpp
@@ -590,6 +590,7 @@ namespace daxa
         std::span<std::byte const> attachment_shader_blob = {};
         std::string_view task_name = {};
 
+#if !DAXA_REMOVE_DEPRECATED
         [[deprecated("Use AttachmentBlob(std::span<std::byte const>) constructor instead")]] void assign_attachment_shader_blob(std::span<std::byte> arr) const
         {
             std::memcpy(
@@ -597,6 +598,7 @@ namespace daxa
                 attachment_shader_blob.data(),
                 attachment_shader_blob.size());
         }
+#endif
 
         auto get(TaskBufferAttachmentIndex index) const -> TaskBufferAttachmentInfo const &;
         auto get(TaskBufferView view) const -> TaskBufferAttachmentInfo const &;

--- a/src/cpp_wrapper.cpp
+++ b/src/cpp_wrapper.cpp
@@ -179,6 +179,7 @@ namespace daxa
         return ret;
     }
 
+#if !DAXA_REMOVE_DEPRECATED
     auto Instance::create_device(DeviceInfo const & info) -> Device
     {
         Device ret = {};
@@ -189,6 +190,7 @@ namespace daxa
                      "failed to create device");
         return ret;
     }
+#endif
 
     auto Instance::create_device_2(DeviceInfo2 const & info) -> Device
     {
@@ -241,10 +243,12 @@ namespace daxa
 
     /// --- Begin Device ---
 
+#if !DAXA_REMOVE_DEPRECATED
     auto default_device_score(DeviceProperties const & device_props) -> i32
     {
         return daxa_default_device_score(r_cast<daxa_DeviceProperties const *>(&device_props));
     }
+#endif
 
     auto Device::create_memory(MemoryBlockInfo const & info) -> MemoryBlock
     {

--- a/src/impl_pipeline.cpp
+++ b/src/impl_pipeline.cpp
@@ -73,7 +73,7 @@ auto daxa_dvc_create_raster_pipeline(daxa_Device device, daxa_RasterPipelineInfo
     DAXA_DECL_TRY_CREATE_MODULE(tesselation_control, TESSELLATION_CONTROL_BIT)
     DAXA_DECL_TRY_CREATE_MODULE(tesselation_evaluation, TESSELLATION_EVALUATION_BIT)
     DAXA_DECL_TRY_CREATE_MODULE(fragment, FRAGMENT_BIT)
-    if ((ret.device->properties.implicit_features & ImplicitFeatureFlagBits::MESH_SHADER) != DeviceFlagBits::NONE)
+    if ((ret.device->properties.implicit_features & ImplicitFeatureFlagBits::MESH_SHADER) != ImplicitFeatureFlagBits::NONE)
     {
         DAXA_DECL_TRY_CREATE_MODULE(task, TASK_BIT_EXT)
         DAXA_DECL_TRY_CREATE_MODULE(mesh, MESH_BIT_EXT)

--- a/src/utils/impl_task_graph.cpp
+++ b/src/utils/impl_task_graph.cpp
@@ -3376,12 +3376,12 @@ namespace daxa
                 }
                 if constexpr (std::is_same_v<ChildIdT, BlasId>)
                 {
-                    auto const & child_info = info.device.info_blas(child_id).value();
+                    auto const & child_info = info.device.blas_info(child_id).value();
                     std::format_to(std::back_inserter(out), "{}name: \"{}\", id: ({})\n", indent, child_info.name.view(), to_string(child_id));
                 }
                 if constexpr (std::is_same_v<ChildIdT, TlasId>)
                 {
-                    auto const & child_info = info.device.info_tlas(child_id).value();
+                    auto const & child_info = info.device.tlas_info(child_id).value();
                     std::format_to(std::back_inserter(out), "{}name: \"{}\", id: ({})\n", indent, child_info.name.view(), to_string(child_id));
                 }
             }


### PR DESCRIPTION
This greatly reduces the amount of warnings when compiling Daxa.

To limit changes, DAXA_REMOVE_DEPRECATED was not added to the C API.

Minor fixes to impl_pipeline.cpp and impl_task_graph.cpp are bundled with this commit, so that everything compiles with DAXA_REMOVE_DEPRECATED 1.