### PR TITLE
Handle SUBOPTIMAL_KHR on resize event

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce UNIX line endings
+* text=auto eol=lf

--- a/src/cpp_wrapper.cpp
+++ b/src/cpp_wrapper.cpp
@@ -793,7 +793,8 @@ namespace daxa
         auto result = daxa_swp_acquire_next_image(r_cast<daxa_Swapchain>(this->object), r_cast<daxa_ImageId *>(&ret));
         if (result == DAXA_RESULT_ERROR_OUT_OF_DATE_KHR ||
             result == DAXA_RESULT_ERROR_SURFACE_LOST_KHR ||
-            result == DAXA_RESULT_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
+            result == DAXA_RESULT_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT ||
+            result == DAXA_RESULT_SUBOPTIMAL_KHR)
         {
             return {};
         }


### PR DESCRIPTION
## Changes

- Adds a `.gitattributes` file to transparently normalise line endings
  - Was getting warnings in CLion that it was going to commit CRLF. I've set the desired eol character to LF in the file but can just as easily be set to CRLF and still ensure consistent endings at the git level
  - ⬆️ You can locally configure git to do this, but with the attributes file it's set for all developers
- Includes `DAXA_RESULT_SUBOPTIMAL_KHR` in the list of statuses which return a null image from acquire

Tested on Wayland with an AMD card. We've got one dev on Windows with Nvidia too who can test but I'd be surprised if this broke anything there

https://github.com/user-attachments/assets/8495403d-0077-46b3-8f7e-15b34da10681