### PR TITLE
Fixed compilation error for clang-win64

### DIFF
--- a/include/daxa/utils/task_graph.hpp
+++ b/include/daxa/utils/task_graph.hpp
@@ -255,8 +255,6 @@ namespace daxa
         static constexpr inline usize ATTACHMENT_COUNT = 0;
     };
 
-    DAXA_EXPORT_CXX auto task_type_default_stage(TaskType task_type) -> TaskStage;
-
     DAXA_EXPORT_CXX auto error_message_unassigned_buffer_view(std::string_view task_name, std::string_view attachment_name) -> std::string;
     DAXA_EXPORT_CXX auto error_message_unassigned_image_view(std::string_view task_name, std::string_view attachment_name) -> std::string;
     DAXA_EXPORT_CXX auto error_message_unassigned_tlas_view(std::string_view task_name, std::string_view attachment_name) -> std::string;

--- a/include/daxa/utils/task_graph_types.hpp
+++ b/include/daxa/utils/task_graph_types.hpp
@@ -316,7 +316,7 @@ namespace daxa
 
     auto task_type_allowed_stages(TaskType task_type, TaskStage stage) -> bool;
 
-    auto task_type_default_stage(TaskType task_type) -> TaskStage;
+    DAXA_EXPORT_CXX auto task_type_default_stage(TaskType task_type) -> TaskStage;
 
     using TaskResourceIndex = u32;
 


### PR DESCRIPTION
I am not sure if you like this fix but it wasn't compiling on my system