### PR TITLE
move struct decl outside of unnamed union, fix std::max bug

### DIFF
--- a/src/utils/impl_task_graph.cpp
+++ b/src/utils/impl_task_graph.cpp
@@ -1833,7 +1833,7 @@ namespace daxa
         usize first_possible_batch_index = 0;
         if (!impl.info.reorder_tasks)
         {
-            first_possible_batch_index = std::max(queue_submit_scope.task_batches.size(), static_cast<size_t>(1ull)) - 1ull;
+            first_possible_batch_index = std::max(queue_submit_scope.task_batches.size(), static_cast<decltype(queue_submit_scope.task_batches.size())>(1)) - 1ull;
         }
 
         for_each(
@@ -2207,7 +2207,7 @@ namespace daxa
     void validate_task_queue_insertion(ImplTaskGraph & impl, TaskGraphPermutation & perm, ImplTask & task, Queue queue)
     {
         // Its invalid to use any other queue than the default queue in the first submit scope!
-        u32 const current_submit_scope = static_cast<u32>(std::max(perm.batch_submit_scopes.size(), 1ull) - 1ull);
+        u32 const current_submit_scope = static_cast<u32>(std::max(perm.batch_submit_scopes.size(), static_cast<decltype(perm.batch_submit_scopes.size())>(1ull)) - 1ull);
         if (current_submit_scope == 0)
         {
             bool const is_default_queue = queue == impl.info.default_queue;

--- a/src/utils/impl_task_graph_mk2.hpp
+++ b/src/utils/impl_task_graph_mk2.hpp
@@ -156,24 +156,25 @@ namespace daxa
 
         MemoryArena * allocator = {};
         u32 element_count = {};
+        struct DebugView
+        {
+            T (*block_allocation0)[BLOCK_SIZES[0]];
+            T (*block_allocation1)[BLOCK_SIZES[1]];
+            T (*block_allocation2)[BLOCK_SIZES[2]];
+            T (*block_allocation3)[BLOCK_SIZES[3]];
+            T (*block_allocation4)[BLOCK_SIZES[4]];
+            T (*block_allocation5)[BLOCK_SIZES[5]];
+            T (*block_allocation6)[BLOCK_SIZES[6]];
+            T (*block_allocation7)[BLOCK_SIZES[7]];
+            T (*block_allocation8)[BLOCK_SIZES[8]];
+            T (*block_allocation9)[BLOCK_SIZES[9]];
+            T (*block_allocation10)[BLOCK_SIZES[10]];
+            T (*block_allocation11)[BLOCK_SIZES[11]];
+        };
         union
         {
             T * block_allocations[BLOCK_COUNT] = {};
-            struct DebugView
-            {
-                T (*block_allocation0)[BLOCK_SIZES[0]];
-                T (*block_allocation1)[BLOCK_SIZES[1]];
-                T (*block_allocation2)[BLOCK_SIZES[2]];
-                T (*block_allocation3)[BLOCK_SIZES[3]];
-                T (*block_allocation4)[BLOCK_SIZES[4]];
-                T (*block_allocation5)[BLOCK_SIZES[5]];
-                T (*block_allocation6)[BLOCK_SIZES[6]];
-                T (*block_allocation7)[BLOCK_SIZES[7]];
-                T (*block_allocation8)[BLOCK_SIZES[8]];
-                T (*block_allocation9)[BLOCK_SIZES[9]];
-                T (*block_allocation10)[BLOCK_SIZES[10]];
-                T (*block_allocation11)[BLOCK_SIZES[11]];
-            } debug_view;
+            DebugView debug_view;
         };
 
         struct BlockIndex


### PR DESCRIPTION
Fixes linux clang builds as far as I'm aware