### PR TITLE
fix: link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Other than the focus on modern architecture only, what makes Daxa unique?
 
 ## Getting started
 
-To begin using Daxa, visit [daxa.dev](https://daxa.dev/), where you'll find a comprehensive tutorial and a Wiki containing detailed information about the Daxa API.
+To begin using Daxa, visit [docs.daxa.dev](https://docs.daxa.dev/), where you'll find a comprehensive tutorial and a Wiki containing detailed information about the Daxa API.
 
-- [Daxa Tutorial](https://tutorial.daxa.dev/)
-- [Daxa Wiki](https://wiki.daxa.dev/)
+* [Daxa Tutorial](https://docs.daxa.dev/tutorial/)
+* [Daxa Wiki](https://docs.daxa.dev/wiki/)
 
-Additionally, the Daxa repository includes a collection of example projects located in the **tests** folder
+Additionally, the Daxa repository includes a collection of example projects located in the **tests** folder.
 
 Working on something with Daxa? Whether it's a renderer, a tool, or just a small experiment—feel free to share it or ask questions on the [Discord server](https://discord.gg/MJPJvZ4FK5). It’s a good place to connect with others using Daxa and stay up to date with ongoing work.


### PR DESCRIPTION
This pull request updates the documentation links in the `README.md` to point to the new documentation domain. The changes help ensure users are directed to the correct and most up-to-date resources for tutorials and the Wiki.

* Documentation links updated to use `docs.daxa.dev` for the main site, tutorial, and Wiki, replacing the previous separate domains.