### PR TITLE
Fix cmake warning

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -74,6 +74,7 @@ if (DAXA_ENABLE_UTILS_PIPELINE_MANAGER_SLANG AND NOT TARGET slang::slang)
         slang
         URL https://github.com/shader-slang/slang/releases/download/v${Slang_VERSION}/slang-${Slang_VERSION}-windows-x86_64.zip
         # URL https://github.com/shader-slang/slang/releases/download/v2025.11/slang-2025.11-windows-x86_64.zip
+        DOWNLOAD_EXTRACT_TIMESTAMP 1
     )
     FetchContent_MakeAvailable(slang)
 


### PR DESCRIPTION
to prevent cmake warning we need to set policy to keep using old behaviour or add DOWNLOAD_EXTRACT_TIMESTAMP to switch to new, new one always respects changes when we change the URL so it's better in this use case

warning:
```
CMake Warning (dev) at C:/Program Files/JetBrains/CLion 2025.2.3/bin/cmake/win/x64/share/cmake-4.0/Modules/FetchContent.cmake:1373 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
 ```