### PR TITLE
Proposal: remove `DAXA_DBG_ASSERT_TRUE_MS`

### DIFF
--- a/include/daxa/core.hpp
+++ b/include/daxa/core.hpp
@@ -33,23 +33,9 @@
             throw std::runtime_error("DAXA DEBUG ASSERTION FAILURE");             \
         }                                                                         \
     } while (false)
-#define DAXA_DBG_ASSERT_TRUE_MS(x, STREAM)                                        \
-    do                                                                            \
-    {                                                                             \
-        if (std::is_constant_evaluated())                                         \
-        {                                                                         \
-            /* how do we check this??? static_assert(x); */                       \
-        }                                                                         \
-        else if (!(x))                                                            \
-        {                                                                         \
-            std::cerr << DAXA_DBG_ASSERT_FAIL_STRING << ": " STREAM << std::endl; \
-            throw std::runtime_error("DAXA DEBUG ASSERTION FAILURE");             \
-        }                                                                         \
-    } while (false)
 #else
 
 #define DAXA_DBG_ASSERT_TRUE_M(x, m)
-#define DAXA_DBG_ASSERT_TRUE_MS(x, m)
 
 #endif
 

--- a/src/utils/impl_task_graph.cpp
+++ b/src/utils/impl_task_graph.cpp
@@ -1310,24 +1310,20 @@ namespace daxa
         DAXA_DBG_ASSERT_TRUE_M(!id.is_empty(), "Detected empty task image id. Please make sure to only use initialized task image ids.");
         if (id.is_external())
         {
-            DAXA_DBG_ASSERT_TRUE_MS(
+            DAXA_DBG_ASSERT_TRUE_M(
                 persistent_image_index_to_local_index.contains(id.index),
-                << "Detected invalid access of persistent task image id "
-                << id.index
-                << " in task graph \""
-                << info.name
-                << "\". Please make sure to declare persistent resource use to each task graph that uses this image with the function use_persistent_image!");
+                std::format("Detected invalid access of persistent task image id {} in task graph \"{}\". "
+                            "Please make sure to declare persistent resource use to each task graph that uses this image with the function use_persistent_image!",
+                            id.index, info.name));
             return TaskImageView{.task_graph_index = this->unique_index, .index = persistent_image_index_to_local_index.at(id.index), .slice = id.slice};
         }
         else
         {
-            DAXA_DBG_ASSERT_TRUE_MS(
+            DAXA_DBG_ASSERT_TRUE_M(
                 id.task_graph_index == this->unique_index,
-                << "Detected invalid access of transient task image id "
-                << (id.index)
-                << " in task graph \""
-                << info.name
-                << "\". Please make sure that you only use transient image within the list they are created in!");
+                std::format("Detected invalid access of transient task image id {} in task graph \"{}\". "
+                            "Please make sure that you only use transient image within the list they are created in!",
+                            id.index, info.name));
             return TaskImageView{.task_graph_index = this->unique_index, .index = id.index, .slice = id.slice};
         }
     }

--- a/src/utils/impl_task_graph_mk2.cpp
+++ b/src/utils/impl_task_graph_mk2.cpp
@@ -1304,24 +1304,20 @@ namespace daxa
         DAXA_DBG_ASSERT_TRUE_M(!id.is_empty(), "Detected empty task image id. Please make sure to only use initialized task image ids.");
         if (id.is_external())
         {
-            DAXA_DBG_ASSERT_TRUE_MS(
+            DAXA_DBG_ASSERT_TRUE_M(
                 persistent_image_index_to_local_index.contains(id.index),
-                << "Detected invalid access of persistent task image id "
-                << id.index
-                << " in task graph \""
-                << info.name
-                << "\". Please make sure to declare persistent resource use to each task graph that uses this image with the function use_persistent_image!");
+                std::format("Detected invalid access of persistent task image id {} in task graph \"{}\". "
+                            "Please make sure to declare persistent resource use to each task graph that uses this image with the function use_persistent_image!",
+                            id.index, info.name));
             return TaskImageView{.task_graph_index = this->unique_index, .index = persistent_image_index_to_local_index.at(id.index), .slice = id.slice};
         }
         else
         {
-            DAXA_DBG_ASSERT_TRUE_MS(
+            DAXA_DBG_ASSERT_TRUE_M(
                 id.task_graph_index == this->unique_index,
-                << "Detected invalid access of transient task image id "
-                << (id.index)
-                << " in task graph \""
-                << info.name
-                << "\". Please make sure that you only use transient image within the list they are created in!");
+                std::format("Detected invalid access of transient task image id {} in task graph \"{}\". "
+                            "Please make sure that you only use transient image within the list they are created in!",
+                            id.index, info.name));
             return TaskImageView{.task_graph_index = this->unique_index, .index = id.index, .slice = id.slice};
         }
     }


### PR DESCRIPTION
Replace the only couple occurrences of it with `DAXA_DBG_ASSERT_TRUE_M` + `std::format` since that's already a pattern used in the code.

(Impetus: submit parts of https://github.com/Ipotrick/Daxa/pull/98; so do not hesitate to close if undesirable.)