### PR TITLE
Fix type casting in cpu timeline value function

### DIFF
--- a/src/impl_swapchain.cpp
+++ b/src/impl_swapchain.cpp
@@ -219,7 +219,7 @@ auto daxa_swp_gpu_timeline_semaphore(daxa_Swapchain self) -> daxa_TimelineSemaph
 
 auto daxa_swp_current_cpu_timeline_value(daxa_Swapchain self) -> u64
 {
-    return static_cast<u64>(std::max(0ll, self->cpu_frame_timeline));
+    return static_cast<u64>(std::max(i64{0}, self->cpu_frame_timeline));
 }
 
 auto daxa_swp_info(daxa_Swapchain self) -> daxa_SwapchainInfo const *


### PR DESCRIPTION
Backport from https://github.com/microsoft/vcpkg/pull/48661.

Code to reproduce the compile issue: https://godbolt.org/z/z1nKKrsWz

Note: The line break at eof was automatically added by the GitHub editor and get avoid it (or just by really checking the repo out)