### PR TITLE
[FIX] linux GCC and CLANG max compiler error

### DIFF
--- a/src/impl_core.hpp
+++ b/src/impl_core.hpp
@@ -227,7 +227,7 @@ namespace daxa
         MemoryArena() = default;
         MemoryArena(std::string_view name, u64 a_size)
         {
-            a_size = std::max(sizeof(u8) * name.size() + 1ull, a_size);
+            a_size = std::max<uint64_t>(sizeof(u8) * name.size() + 1ull, a_size);            this->owned_memory = static_cast<u8*>(::operator new[](a_size, std::align_val_t(alignof(void*))));
             this->owned_memory = static_cast<u8*>(::operator new[](a_size, std::align_val_t(alignof(void*))));
             this->owned_memory_count += 1ull;
             this->memory = this->owned_memory;

--- a/src/impl_core.hpp
+++ b/src/impl_core.hpp
@@ -227,7 +227,7 @@ namespace daxa
         MemoryArena() = default;
         MemoryArena(std::string_view name, u64 a_size)
         {
-            a_size = std::max<uint64_t>(sizeof(u8) * name.size() + 1ull, a_size);            this->owned_memory = static_cast<u8*>(::operator new[](a_size, std::align_val_t(alignof(void*))));
+            a_size = std::max<uint64_t>(sizeof(u8) * name.size() + 1ull, a_size);
             this->owned_memory = static_cast<u8*>(::operator new[](a_size, std::align_val_t(alignof(void*))));
             this->owned_memory_count += 1ull;
             this->memory = this->owned_memory;


### PR DESCRIPTION
Hello,

Quick note on this PR: it currently does not compile on Linux with GCC or Clang due to a type ambiguity in the max call:

no matching function for call to ‘max(long long unsigned int, uint64_t)’

The issue appears to be caused by the two arguments resolving to different unsigned integer types.

Best regards,
MD