### PR TITLE
Fix nullptr passed to std::runtime_error constructor

### DIFF
--- a/src/cpp_wrapper.cpp
+++ b/src/cpp_wrapper.cpp
@@ -169,7 +169,7 @@ void check_result(daxa_Result result, char const * message, std::array<daxa_Resu
                          message)
                   << std::flush;
 #endif
-        throw std::runtime_error({});
+        throw std::runtime_error(message);
     }
 }
 


### PR DESCRIPTION
One of those C++ footguns,  `std::runtime_error({})` resolves to the overload taking a `const char*`, so we end up passing a nullptr to the constructor.

Mini repro: https://gcc.godbolt.org/z/Exbvjefnd