### PR TITLE
Fix examples via a `get_native_window_info` method

### DIFF
--- a/tests/0_common/window.hpp
+++ b/tests/0_common/window.hpp
@@ -61,31 +61,26 @@ struct AppWindow
         glfwTerminate();
     }
 
-    auto get_native_handle() -> daxa::NativeWindowHandle
+    auto get_native_window_info() -> daxa::NativeWindowInfo
     {
 #if defined(_WIN32)
         return glfwGetWin32Window(glfw_window_ptr);
 #elif defined(__linux__)
-        switch (get_native_platform())
+        switch (glfwGetPlatform())
         {
-        case daxa::NativeWindowPlatform::WAYLAND_API:
-            return reinterpret_cast<daxa::NativeWindowHandle>(glfwGetWaylandWindow(glfw_window_ptr));
-        case daxa::NativeWindowPlatform::XLIB_API:
+        case GLFW_PLATFORM_WAYLAND:
+            return daxa::NativeWindowInfoWayland {
+                .display = glfwGetWaylandDisplay(),
+                .surface = glfwGetWaylandWindow(glfw_window_ptr),
+                .width   = size_x,
+                .height  = size_y,
+            };
         default:
-            return reinterpret_cast<daxa::NativeWindowHandle>(glfwGetX11Window(glfw_window_ptr));
+            return daxa::NativeWindowInfoXlib {
+                .window = reinterpret_cast<void*>(glfwGetX11Window(glfw_window_ptr))
+            };
         }
 #endif
-    }
-
-    auto get_native_platform() -> daxa::NativeWindowPlatform
-    {
-        switch(glfwGetPlatform())
-        {
-        case GLFW_PLATFORM_WIN32: return daxa::NativeWindowPlatform::WIN32_API;
-        case GLFW_PLATFORM_X11: return daxa::NativeWindowPlatform::XLIB_API;
-        case GLFW_PLATFORM_WAYLAND: return daxa::NativeWindowPlatform::WAYLAND_API;
-        default: return daxa::NativeWindowPlatform::UNKNOWN;
-        }
     }
 
     inline void set_mouse_pos(f32 x, f32 y)

--- a/tests/2_daxa_api/3_command_recorder/main.cpp
+++ b/tests/2_daxa_api/3_command_recorder/main.cpp
@@ -1,6 +1,7 @@
 #include <daxa/daxa.hpp>
 #include <iostream>
 #include <chrono>
+#include <cstring>
 #include "../../0_common/shared.hpp"
 
 struct App

--- a/tests/2_daxa_api/5_swapchain/main.cpp
+++ b/tests/2_daxa_api/5_swapchain/main.cpp
@@ -11,8 +11,7 @@ namespace tests
             daxa::Device device = daxa_ctx.create_device_2(daxa_ctx.choose_device({}, {}));
 
             daxa::Swapchain swapchain = device.create_swapchain({
-                .native_window = get_native_handle(),
-                .native_window_platform = get_native_platform(),
+                .native_window_info = get_native_window_info(),
                 .present_mode = daxa::PresentMode::FIFO,
                 .image_usage = daxa::ImageUsageFlagBits::TRANSFER_DST,
                 .name = ("swapchain (simple_creation)"),
@@ -41,8 +40,7 @@ namespace tests
             daxa::Device device = daxa_ctx.create_device_2(daxa_ctx.choose_device({},{}));
 
             daxa::Swapchain swapchain = device.create_swapchain({
-                .native_window = get_native_handle(),
-                .native_window_platform = get_native_platform(),
+                .native_window_info = get_native_window_info(),
                 .image_usage = daxa::ImageUsageFlagBits::TRANSFER_DST,
                 .name = ("swapchain (clearcolor)"),
             });

--- a/tests/4_hello_daxa/1_pink_screen/main.cpp
+++ b/tests/4_hello_daxa/1_pink_screen/main.cpp
@@ -5,24 +5,29 @@
 #define GLFW_EXPOSE_NATIVE_WIN32
 #elif defined(__linux__)
 #define GLFW_EXPOSE_NATIVE_X11
+#define GLFW_EXPOSE_NATIVE_WAYLAND
 #endif
 #include <GLFW/glfw3native.h>
 
-auto get_native_handle(GLFWwindow * glfw_window_ptr) -> daxa::NativeWindowHandle
+auto get_native_window_info(GLFWwindow * glfw_window_ptr, daxa::u32 width, daxa::u32 height) -> daxa::NativeWindowInfo
 {
 #if defined(_WIN32)
     return glfwGetWin32Window(glfw_window_ptr);
 #elif defined(__linux__)
-    return reinterpret_cast<daxa::NativeWindowHandle>(glfwGetX11Window(glfw_window_ptr));
-#endif
-}
-
-auto get_native_platform(GLFWwindow * /*unused*/) -> daxa::NativeWindowPlatform
-{
-#if defined(_WIN32)
-    return daxa::NativeWindowPlatform::WIN32_API;
-#elif defined(__linux__)
-    return daxa::NativeWindowPlatform::XLIB_API;
+    switch (glfwGetPlatform())
+    {
+    case GLFW_PLATFORM_WAYLAND:
+        return daxa::NativeWindowInfoWayland {
+            .display = glfwGetWaylandDisplay(),
+            .surface = glfwGetWaylandWindow(glfw_window_ptr),
+            .width   = width,
+            .height  = height,
+        };
+    default:
+        return daxa::NativeWindowInfoXlib {
+            .window = reinterpret_cast<void*>(glfwGetX11Window(glfw_window_ptr))
+        };
+    }
 #endif
 }
 
@@ -52,8 +57,6 @@ auto main() -> int
             info.width = static_cast<daxa::u32>(width);
             info.height = static_cast<daxa::u32>(height);
         });
-    auto * native_window_handle = get_native_handle(glfw_window_ptr);
-    auto native_window_platform = get_native_platform(glfw_window_ptr);
 
     // First thing we do is create a Daxa instance. This essentially exists
     // to initialize the Vulkan instance, and allows for the creation of multiple
@@ -126,11 +129,7 @@ auto main() -> int
     // format type selector, the additional image uses (image uses will be explained later),
     // and present mode (this controls sync)
     daxa::Swapchain swapchain = device.create_swapchain({
-        // this handle is given by the windowing API
-        .native_window = native_window_handle,
-        // The platform would also be retrieved from the windowing API,
-        // or by hard-coding it depending on the OS.
-        .native_window_platform = native_window_platform,
+        .native_window_info = get_native_window_info(glfw_window_ptr, window_info.width, window_info.height),
         .surface_format_selector = [](daxa::Format format, daxa::ColorSpace colorspace)
         {
             switch (format)


### PR DESCRIPTION
`daxa::NativeWindowHandle` was removed so now  `daxa::NativeWindowInfo` needs to be used. I'm not 100% sure that this is implemented for Wayland correctly.

In addition, `#include <cstring>` is needed for `memcpy` in the command recorder example on Linux.

```cpp
/home/ashley/projects/daxa/tests/2_daxa_api/3_command_recorder/main.cpp:531:18: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’?
  531 |             std::memcpy(device.buffer_host_address(vertex_buffer).value(), &vertices, sizeof(decltype(vertices)));
      |                  ^~~~~~
      |                  wmemcpy
```

This is all that's required for things to compile, but I think a few more changes are needed for the examples to run well, at least on Linux. it doesn't seem to like how the command recorder is destructed:

```
Thread 1 "daxa_test_4_hel" received signal SIGSEGV, Segmentation fault.
0x00005555555a92db in daxa_destroy_command_recorder ()
(gdb) bt
#0  0x00005555555a92db in daxa_destroy_command_recorder ()
#1  0x00005555555a9381 in daxa::CommandRecorder::~CommandRecorder() ()
#2  0x000055555556e474 in main ()
(gdb)```

Simply commenting out `recorder.~CommandRecorder()` seems to work.