### PR TITLE
More fixes for Linux/GCC

### DIFF
--- a/src/utils/impl_resource_viewer.cpp
+++ b/src/utils/impl_resource_viewer.cpp
@@ -956,7 +956,7 @@ namespace daxa
             // Everything must begin with a struct keyword.
             if(! work_code.starts_with("struct"))
             {
-                result.error_message = std::format("Expected 'struct' keyword got \"{}...\"", work_code.substr(0, std::min(work_code.size(), 20ull)));
+                result.error_message = std::format("Expected 'struct' keyword got \"{}...\"", work_code.substr(0, std::min<uint64_t>(work_code.size(), 20ull)));
                 return result;
             }
             // Skip struct keyword.
@@ -979,7 +979,7 @@ namespace daxa
             // Expect opening brace.
             if(! work_code.starts_with("{"))
             {
-                result.error_message = std::format("Expected '{{' after struct name '{}', got \"{}...\"", struct_name, work_code.substr(0, std::min(work_code.size(), 20ull)));
+                result.error_message = std::format("Expected '{{' after struct name '{}', got \"{}...\"", struct_name, work_code.substr(0, std::min<uint64_t>(work_code.size(), 20ull)));
                 return result;
             }
             work_code = work_code.substr(1);
@@ -994,7 +994,7 @@ namespace daxa
                     work_code = work_code.substr(1);
                     if(!work_code.starts_with(";"))
                     {
-                        result.error_message = std::format("Expected ';' after closing '}}' of struct '{}', got \"{}...\"", struct_name, work_code.substr(0, std::min(work_code.size(), 20ull)));
+                        result.error_message = std::format("Expected ';' after closing '}}' of struct '{}', got \"{}...\"", struct_name, work_code.substr(0, std::min<uint64_t>(work_code.size(), 20ull)));
                         return result;
                     }
                     work_code = work_code.substr(1);
@@ -1026,7 +1026,7 @@ namespace daxa
                     pointer_depth = 1;
                     if(!member_type.ends_with(")"))
                     {
-                        result.error_message = std::format("Expected closing ')' for buffer pointer type in struct '{}', got \"{}...\"", struct_name, work_code.substr(0, std::min(work_code.size(), 20ull)));
+                        result.error_message = std::format("Expected closing ')' for buffer pointer type in struct '{}', got \"{}...\"", struct_name, work_code.substr(0, std::min<uint64_t>(work_code.size(), 20ull)));
                         return result;
                     }
                     member_type.remove_prefix(member_type.find('(') + 1);
@@ -1137,7 +1137,7 @@ namespace daxa
 
                 if(!work_code.starts_with(";"))
                 {
-                    result.error_message = std::format("Expected ';' after member declaration of '{}' in struct '{}', got \"{}...\"", member_name, struct_name, work_code.substr(0, std::min(work_code.size(), 20ull)));
+                    result.error_message = std::format("Expected ';' after member declaration of '{}' in struct '{}', got \"{}...\"", member_name, struct_name, work_code.substr(0, std::min<uint64_t>(work_code.size(), 20ull)));
                     return result;
                 }
                 work_code = work_code.substr(1);

--- a/src/utils/impl_resource_viewer.cpp
+++ b/src/utils/impl_resource_viewer.cpp
@@ -1335,7 +1335,7 @@ namespace daxa
                             break;
                         }
                         }
-                        ImGui::Text(std::format("Min {:#010x} Max {:#010x}", hex_min, hex_max).c_str());
+                        ImGui::Text("%s", std::format("Min {:#010x} Max {:#010x}", hex_min, hex_max).c_str());
                     }
                     else
                     {
@@ -1343,17 +1343,17 @@ namespace daxa
                         {
                         case ScalarKind::FLOAT:
                         {
-                            ImGui::Text(std::format("Min {:<10.3} Max {:<10.3}", min_value, max_value).c_str());
+                            ImGui::Text("%s", std::format("Min {:<10.3} Max {:<10.3}", min_value, max_value).c_str());
                             break;
                         }
                         case ScalarKind::INT:
                         {
-                            ImGui::Text(std::format("Min {:<10} Max {:<10}", static_cast<i32>(min_value), static_cast<i32>(max_value)).c_str());
+                            ImGui::Text("%s", std::format("Min {:<10} Max {:<10}", static_cast<i32>(min_value), static_cast<i32>(max_value)).c_str());
                             break;
                         }
                         case ScalarKind::UINT:
                         {
-                            ImGui::Text(std::format("Min {:<10} Max {:<10}", static_cast<u32>(min_value), static_cast<u32>(max_value)).c_str());
+                            ImGui::Text("%s", std::format("Min {:<10} Max {:<10}", static_cast<u32>(min_value), static_cast<u32>(max_value)).c_str());
                             break;
                         }
                         }
@@ -1495,28 +1495,28 @@ namespace daxa
                         if (ImGui::IsItemHovered())
                         {
                             ImGui::BeginTooltip();
-                            ImGui::Text(std::format("{}, {}", static_cast<i32>(mouse_pos.x), static_cast<i32>(mouse_pos.y)).c_str());
+                            ImGui::Text("%s", std::format("{}, {}", static_cast<i32>(mouse_pos.x), static_cast<i32>(mouse_pos.y)).c_str());
 
                             if (state.display_as_hexadecimal)
                             {
                                 if (state.image.enabled_channels.x)
                                 {
-                                    ImGui::Text(std::format("R {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.x)).c_str());
+                                    ImGui::Text("%s", std::format("R {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.x)).c_str());
                                     ImGui::SameLine();
                                 }
                                 if (state.image.enabled_channels.y)
                                 {
-                                    ImGui::Text(std::format("G {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.y)).c_str());
+                                    ImGui::Text("%s", std::format("G {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.y)).c_str());
                                     ImGui::SameLine();
                                 }
                                 if (state.image.enabled_channels.z)
                                 {
-                                    ImGui::Text(std::format("B {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.z)).c_str());
+                                    ImGui::Text("%s", std::format("B {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.z)).c_str());
                                     ImGui::SameLine();
                                 }
                                 if (state.image.enabled_channels.w)
                                 {
-                                    ImGui::Text(std::format("A {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.w)).c_str());
+                                    ImGui::Text("%s", std::format("A {:#010x}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.w)).c_str());
                                     ImGui::SameLine();
                                 }
                                 ImGui::Dummy({});
@@ -1529,22 +1529,22 @@ namespace daxa
                                 {
                                     if (state.image.enabled_channels.x)
                                     {
-                                        ImGui::Text(std::format("R {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.x))).c_str());
+                                        ImGui::Text("%s", std::format("R {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.x))).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.y)
                                     {
-                                        ImGui::Text(std::format("G {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.y))).c_str());
+                                        ImGui::Text("%s", std::format("G {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.y))).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.z)
                                     {
-                                        ImGui::Text(std::format("B {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.z))).c_str());
+                                        ImGui::Text("%s", std::format("B {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.z))).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.w)
                                     {
-                                        ImGui::Text(std::format("A {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.w))).c_str());
+                                        ImGui::Text("%s", std::format("A {:<10.3}", static_cast<f64>(std::bit_cast<f32>(state.image.latest_readback.hovered_value.w))).c_str());
                                     }
                                     ImGui::Dummy({});
                                     break;
@@ -1554,22 +1554,22 @@ namespace daxa
 
                                     if (state.image.enabled_channels.x)
                                     {
-                                        ImGui::Text(std::format("R {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.x)).c_str());
+                                        ImGui::Text("%s", std::format("R {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.x)).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.y)
                                     {
-                                        ImGui::Text(std::format("G {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.y)).c_str());
+                                        ImGui::Text("%s", std::format("G {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.y)).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.z)
                                     {
-                                        ImGui::Text(std::format("B {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.z)).c_str());
+                                        ImGui::Text("%s", std::format("B {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.z)).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.w)
                                     {
-                                        ImGui::Text(std::format("A {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.w)).c_str());
+                                        ImGui::Text("%s", std::format("A {:<10}", std::bit_cast<i32>(state.image.latest_readback.hovered_value.w)).c_str());
                                     }
                                     ImGui::Dummy({});
                                     break;
@@ -1578,22 +1578,22 @@ namespace daxa
                                 {
                                     if (state.image.enabled_channels.x)
                                     {
-                                        ImGui::Text(std::format("R {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.x)).c_str());
+                                        ImGui::Text("%s", std::format("R {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.x)).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.y)
                                     {
-                                        ImGui::Text(std::format("G {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.y)).c_str());
+                                        ImGui::Text("%s", std::format("G {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.y)).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.z)
                                     {
-                                        ImGui::Text(std::format("B {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.z)).c_str());
+                                        ImGui::Text("%s", std::format("B {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.z)).c_str());
                                         ImGui::SameLine();
                                     }
                                     if (state.image.enabled_channels.w)
                                     {
-                                        ImGui::Text(std::format("A {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.w)).c_str());
+                                        ImGui::Text("%s", std::format("A {:<10}", std::bit_cast<u32>(state.image.latest_readback.hovered_value.w)).c_str());
                                     }
                                     ImGui::Dummy({});
                                     break;
@@ -1685,7 +1685,7 @@ namespace daxa
                         if (state.buffer.format_c_struct_code_compile_error_message.size() > 0)
                         {
                             ImGui::PushStyleColor(ImGuiCol_Text, ColorPalette::RED);
-                            ImGui::TextWrapped(state.buffer.format_c_struct_code_compile_error_message.data());
+                            ImGui::TextWrapped("%s", state.buffer.format_c_struct_code_compile_error_message.data());
                             ImGui::PopStyleColor();
                         }
                         ImGui::InputTextMultiline("##input", state.buffer.format_c_struct_code.data(), state.buffer.format_c_struct_code.size(), ImGui::GetContentRegionAvail());
@@ -1812,11 +1812,11 @@ namespace daxa
                         if (is_pointer)
                         {
                             std::string text = std::format("{}{}", type_def.name, std::string(field_def.pointer_depth, '*'));
-                            ImGui::Text(text.c_str());
+                            ImGui::Text("%s", text.c_str());
                         }
                         else
                         {
-                            ImGui::Text(type_def.name.c_str());
+                            ImGui::Text("%s", type_def.name.c_str());
                         }
                         ImGui::TableNextColumn();
                         if (is_array)
@@ -1840,57 +1840,57 @@ namespace daxa
                             {
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_F16:
                                 {
-                                    ImGui::Text(std::format({":#05x"}, *reinterpret_cast<u16 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format({":#05x"}, *reinterpret_cast<u16 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_F32: 
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<f32 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<f32 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_F64:
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<f64 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<f64 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_I8:
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<i8 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<i8 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_I16:
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<i16 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<i16 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_I32: 
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<i32 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<i32 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_I64:
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<i64 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<i64 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_U8:
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<u8 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<u8 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_U16:
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<u16 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<u16 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_U32: 
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<u32 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<u32 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                                 case TG_DEBUG_PRIMITIVE_TYPE_INDEX_U64: 
                                 {
-                                    ImGui::Text(std::format("{}", *reinterpret_cast<u64 const*>(readback_ptr + memory_offset)).c_str());
+                                    ImGui::Text("%s", std::format("{}", *reinterpret_cast<u64 const*>(readback_ptr + memory_offset)).c_str());
                                 }
                                 break;
                             }
@@ -1964,7 +1964,7 @@ namespace daxa
                         ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed, TYPE_COL_WIDTH);
                         ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_None);
                         ImGui::TableNextColumn();
-                        ImGui::Text(type_def.name.c_str());
+                        ImGui::Text("%s", type_def.name.c_str());
                         ImGui::TableNextColumn();
                         if (array_index != ~0u)
                         {
@@ -2008,7 +2008,7 @@ namespace daxa
                                     ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_None);
                                     ImGui::TableSetupColumn("Settings", ImGuiTableColumnFlags_None);
                                     ImGui::TableNextColumn();
-                                    ImGui::Text(field_type_def.name.c_str());
+                                    ImGui::Text("%s", field_type_def.name.c_str());
                                     ImGui::TableNextColumn();
                                     ImGui::Text("%s[%i]", field_def.name.c_str(), field_def.array_size);
                                     ImGui::TableNextColumn();
@@ -2128,7 +2128,7 @@ namespace daxa
 
                                     auto child_readback_host_ptr = context.device.buffer_host_address(child_viewer_state.clone_buffer).value();
 
-                                    ImGui::Text(std::format("pointer address to \"{:<32}\" offset {:<20}", info.name.c_str(), child_viewer_state.base_offset).c_str());
+                                    ImGui::Text("%s", std::format("pointer address to \"{:<32}\" offset {:<20}", info.name.c_str(), child_viewer_state.base_offset).c_str());
                                     ImGui::SetNextItemWidth(120);
                                     ImGui::InputInt("Array Size", &child_viewer_state.display_array_size);
                                     ImGui::SameLine();

--- a/src/utils/impl_task_graph.cpp
+++ b/src/utils/impl_task_graph.cpp
@@ -2867,12 +2867,12 @@ namespace daxa
             }
             else
             {
-                new_allocation.offset = align_up(resource_heap_size, new_allocation_memory_requirements.alignment);
+                new_allocation.offset = align_up<uint64_t>(resource_heap_size, new_allocation_memory_requirements.alignment);
                 non_external_resource_allocations[tr] = new_allocation;
             }
 
-            resource_heap_size = std::max(resource_heap_size, new_allocation.offset + new_allocation.size);
-            resource_heap_alignment = std::max(resource_heap_alignment, new_allocation_memory_requirements.alignment);
+            resource_heap_size = std::max<uint64_t>(resource_heap_size, new_allocation.offset + new_allocation.size);
+            resource_heap_alignment = std::max<uint64_t>(resource_heap_alignment, new_allocation_memory_requirements.alignment);
             resource_heap_memory_bits &= new_allocation_memory_requirements.memory_type_bits;
         }
 

--- a/src/utils/impl_task_graph_ui.cpp
+++ b/src/utils/impl_task_graph_ui.cpp
@@ -414,11 +414,11 @@ namespace daxa
             }
             else
             {
-                for (u32 i = 0; i < std::min(255ull, resource.name.size()); ++i)
+                for (u32 i = 0; i < std::min<uint64_t>(255ull, resource.name.size()); ++i)
                 {
                     ui_context.resource_name_search[i] = resource.name[i];
                 }
-                ui_context.resource_name_search[std::min(255ull, resource.name.size())] = 0;
+                ui_context.resource_name_search[std::min<uint64_t>(255ull, resource.name.size())] = 0;
             }
         }
     }
@@ -479,11 +479,11 @@ namespace daxa
             }
             else
             {
-                for (u32 i = 0; i < std::min(255ull, task.name.size()); ++i)
+                for (u32 i = 0; i < std::min<uint64_t>(255ull, task.name.size()); ++i)
                 {
                     ui_context.task_name_search[i] = task.name[i];
                 }
-                ui_context.task_name_search[std::min(255ull, task.name.size())] = 0;
+                ui_context.task_name_search[std::min<uint64_t>(255ull, task.name.size())] = 0;
             }
         }
     }

--- a/src/utils/impl_task_graph_ui.cpp
+++ b/src/utils/impl_task_graph_ui.cpp
@@ -368,7 +368,7 @@ namespace daxa
                 ImGui::SameLine(15, 15);
             }
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0, 0, 0, 1));
-            ImGui::Text(text.c_str());
+            ImGui::Text("%s", text.c_str());
             ImGui::PopStyleColor();
             ImGui::SameLine();
         }
@@ -599,7 +599,7 @@ namespace daxa
         if (ImGui::BeginPopupContextItem(task.name.data()))
         {
             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, ImGui::GetStyle().FramePadding.y));
-            ImGui::Text(task.name.data());
+            ImGui::Text("%s", task.name.data());
             if (ImGui::Button("Open Task Detail Ui (Double Click)"))
             {
                 if (detail_window_open)
@@ -658,7 +658,7 @@ namespace daxa
         if (ImGui::BeginPopupContextItem(resource.name.data()))
         {
             ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, ImGui::GetStyle().FramePadding.y));
-            ImGui::Text(resource.name.data());
+            ImGui::Text("%s", resource.name.data());
             if (ImGui::Button("Open Resource Detail Ui (Double Click)"))
             {
                 open_or_focus_resource_detail_ui(ui_context, impl_tg, resource_index);
@@ -859,7 +859,7 @@ namespace daxa
                         ImGui::SetCursorScreenPos(clipped_start);
                         auto const size = ImVec2(clipped_end.x - clipped_start.x, clipped_end.y - clipped_start.y);
                         ImGui::InvisibleButton(std::format("##LALA{}", resource.name.data()).c_str(), size);
-                        ImGui::SetItemTooltip(resource.name.data());
+                        ImGui::SetItemTooltip("%s", resource.name.data());
                         resource_popup_context_ui(ui_context, impl_tg, resource_index, true);
                         ImVec4 const fill_color = resource_kind_to_color(resource.kind);
                         ImVec4 const fill_color_final = ImGui::IsItemHovered() ? ImVec4(fill_color.x * 1.3f, fill_color.y * 1.3f, fill_color.z * 1.3f, 1.0f) : fill_color;
@@ -1143,12 +1143,12 @@ namespace daxa
                             }
                             else
                             {
-                                ImGui::Text(impl_tg->resources[row_info.resource_index].name.data());
+                                ImGui::Text("%s", impl_tg->resources[row_info.resource_index].name.data());
                             }
                         }
                         else
                         {
-                            ImGui::Text(row_info.cell_text.at(cell_idx).c_str());
+                            ImGui::Text("%s", row_info.cell_text.at(cell_idx).c_str());
                         }
                     }
                     if (row_info.resource_index == ~0u)
@@ -1318,7 +1318,7 @@ namespace daxa
                 set_table_cell_name_color();
                 ImGui::Text("Lifetime");
                 ImGui::TableNextColumn();
-                ImGui::Text(to_string(resource.lifetime_type).data());
+                ImGui::Text("%s", to_string(resource.lifetime_type).data());
 
                 ImGui::TableNextColumn();
                 ImGui::EndTable();
@@ -1328,13 +1328,13 @@ namespace daxa
             {
                 ImGui::TableNextColumn();
                 set_table_cell_name_color();
-                ImGui::Text(resource.double_buffer_index == 0 ? "IS_FRONT_BUFFER" : "IS_BACK_BUFFER");
+                ImGui::Text("%s", resource.double_buffer_index == 0 ? "IS_FRONT_BUFFER" : "IS_BACK_BUFFER");
 
                 ImGui::TableNextColumn();
-                ImGui::Text(resource.double_buffer_index == 0 ? "BACK_BUFFER:" : "FRONT_BUFFER:");
+                ImGui::Text("%s", resource.double_buffer_index == 0 ? "BACK_BUFFER:" : "FRONT_BUFFER:");
                 ImGui::TableNextColumn();
                 set_table_cell_name_color();
-                ImGui::Text(resource.double_buffer_pair_resource.first->name.data());
+                ImGui::Text("%s", resource.double_buffer_pair_resource.first->name.data());
                 resource_popup_context_ui(ui_context, impl_tg, resource.double_buffer_pair_resource.second, false);
 
                 ImGui::TableNextColumn();
@@ -1352,7 +1352,7 @@ namespace daxa
                     set_table_cell_name_color();
                     ImGui::Text("External Resource Link");
                     ImGui::TableNextColumn();
-                    ImGui::Text(resource.external->name.data());
+                    ImGui::Text("%s", resource.external->name.data());
                 }
 
                 switch (resource.kind)
@@ -1407,13 +1407,13 @@ namespace daxa
                     set_table_cell_name_color();
                     ImGui::Text("MemoryFlags");
                     ImGui::TableNextColumn();
-                    ImGui::Text(to_string(memory_flags).data());
+                    ImGui::Text("%s", to_string(memory_flags).data());
 
                     ImGui::TableNextColumn();
                     set_table_cell_name_color();
                     ImGui::Text("Device Address");
                     ImGui::TableNextColumn();
-                    ImGui::Text(std::to_string(device_address).c_str());
+                    ImGui::Text("%s", std::to_string(device_address).c_str());
 
                     if (host_address)
                     {
@@ -1421,7 +1421,7 @@ namespace daxa
                         set_table_cell_name_color();
                         ImGui::Text("Host Address");
                         ImGui::TableNextColumn();
-                        ImGui::Text(std::to_string(host_address).c_str());
+                        ImGui::Text("%s", std::to_string(host_address).c_str());
                     }
 
                     break;
@@ -1435,7 +1435,7 @@ namespace daxa
                     set_table_cell_name_color();
                     ImGui::Text("Format");
                     ImGui::TableNextColumn();
-                    ImGui::Text(to_string(info.format).data());
+                    ImGui::Text("%s", to_string(info.format).data());
 
                     if (info.flags != ImageCreateFlagBits::NONE)
                     {
@@ -1443,14 +1443,14 @@ namespace daxa
                         set_table_cell_name_color();
                         ImGui::Text("Flags");
                         ImGui::TableNextColumn();
-                        ImGui::Text(to_string(info.flags).data());
+                        ImGui::Text("%s", to_string(info.flags).data());
                     }
 
                     ImGui::TableNextColumn();
                     set_table_cell_name_color();
                     ImGui::Text("Usage Flags");
                     ImGui::TableNextColumn();
-                    ImGui::Text(to_string(info.usage).data());
+                    ImGui::Text("%s", to_string(info.usage).data());
 
                     break;
                 }
@@ -1547,7 +1547,7 @@ namespace daxa
                     if (ImGui::BeginTable("Barrier Table", 1, BARRIER_TABLE_FLAGS))
                     {
                         ImGui::TableNextColumn();
-                        ImGui::Text(std::format("Barrier. Src: {} Dst: {}", to_string(ag.final_schedule_pre_barrier->src_access), to_string(ag.final_schedule_pre_barrier->dst_access)).c_str());
+                        ImGui::Text("%s", std::format("Barrier. Src: {} Dst: {}", to_string(ag.final_schedule_pre_barrier->src_access), to_string(ag.final_schedule_pre_barrier->dst_access)).c_str());
                         ImGui::EndTable();
                     }
                 }
@@ -1576,7 +1576,7 @@ namespace daxa
                             color,
                             ImVec4(color.x * 0.6f, color.y * 0.6f, color.z * 0.6f, 1.0f));
                         ImGui::TableNextColumn();
-                        ImGui::Text(task->attachments[attach_i].value.buffer.name);
+                        ImGui::Text("%s", task->attachments[attach_i].value.buffer.name);
                     }
                     ImGui::EndTable();
                 }
@@ -1623,13 +1623,13 @@ namespace daxa
             if (batch_ui.access_group->final_schedule_pre_barrier->src_access.stages != PipelineStageFlagBits::NONE)
             {
                 ImGui::Text("Src:");
-                ImGui::Text(std::format("  Access: {}", to_string(batch_ui.access_group->final_schedule_pre_barrier->src_access)).c_str());
+                ImGui::Text("%s", std::format("  Access: {}", to_string(batch_ui.access_group->final_schedule_pre_barrier->src_access)).c_str());
                 ImGui::Text("  Tasks:");
                 ImGui::SameLine();
                 auto const & src_tasks = batch_ui.access_group->final_schedule_pre_barrier->src_access_group->tasks;
                 for (u32 t = 0; t < src_tasks.size(); ++t)
                 {
-                    ImGui::Text(src_tasks[t].task->name.data());
+                    ImGui::Text("%s", src_tasks[t].task->name.data());
                     if (t < src_tasks.size() - 1)
                     {
                         ImGui::SameLine();
@@ -1639,13 +1639,13 @@ namespace daxa
                 }
             }
             ImGui::Text("Dst:");
-            ImGui::Text(std::format("  Access: {}", to_string(batch_ui.access_group->final_schedule_pre_barrier->dst_access)).c_str());
+            ImGui::Text("%s", std::format("  Access: {}", to_string(batch_ui.access_group->final_schedule_pre_barrier->dst_access)).c_str());
             ImGui::Text("  Tasks:");
             ImGui::SameLine();
             auto const & dst_tasks = batch_ui.access_group->tasks;
             for (u32 t = 0; t < dst_tasks.size(); ++t)
             {
-                ImGui::Text(dst_tasks[t].task->name.data());
+                ImGui::Text("%s", dst_tasks[t].task->name.data());
                 if (t < dst_tasks.size() - 1)
                 {
                     ImGui::SameLine();
@@ -2111,7 +2111,7 @@ namespace daxa
                     float const text_offset = (column_width - text_width) / 2;
                     ImGui::Dummy(ImVec2(0.0f, 0.0f));
                     ImGui::SameLine(text_offset);
-                    ImGui::Text(name);
+                    ImGui::Text("%s", name);
                     ImGui::PopStyleColor();
                     if (!col_ui.is_queue_submit_border && !col_ui.is_submit_border)
                     {
@@ -2194,12 +2194,12 @@ namespace daxa
                         ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, ImGui::ColorConvertFloat4ToU32(ImVec4(0.9, 0.9, 0.9, 1)));
                         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0, 0, 0, 1));
                     }
-                    ImGui::Text(resource.name.data());
+                    ImGui::Text("%s", resource.name.data());
                     if (is_pinned)
                     {
                         ImGui::PopStyleColor();
                     }
-                    ImGui::SetItemTooltip(resource.name.data());
+                    ImGui::SetItemTooltip("%s", resource.name.data());
                     resource_popup_context_ui(ui_context, impl_tg, resource_index, true);
 
                     /// =========================================
@@ -2318,7 +2318,7 @@ namespace daxa
                                         if (ImGui::BeginItemTooltip())
                                         {
                                             TaskAttachmentInfo const & attach_info = col_ui.task->attachments[attachment_index];
-                                            ImGui::Text(std::format("Attachment name: {}", attach_info.value.common.name).c_str());
+                                            ImGui::Text("%s", std::format("Attachment name: {}", attach_info.value.common.name).c_str());
                                             ImGui::EndTooltip();
                                         }
                                         make_cell_darker = false;

--- a/tests/2_daxa_api/3_command_recorder/main.cpp
+++ b/tests/2_daxa_api/3_command_recorder/main.cpp
@@ -503,96 +503,90 @@ namespace tests
     }
     void build_acceleration_structure(App & app)
     {
-            daxa::Device device = app.daxa_ctx.create_device_2(app.daxa_ctx.choose_device(daxa::ImplicitFeatureFlagBits::BASIC_RAY_TRACING, {}));
+        daxa::Device device = app.daxa_ctx.create_device_2(app.daxa_ctx.choose_device(daxa::ImplicitFeatureFlagBits::BASIC_RAY_TRACING, {}));
 
-            /// Prepare mesh data:
-            auto vertices = std::array{
-                std::array{0.25f, 0.75f, 0.5f},
-                std::array{0.5f, 0.25f, 0.5f},
-                std::array{0.75f, 0.75f, 0.5f},
-            };
-            auto vertex_buffer = device.create_buffer({
-                .size = sizeof(decltype(vertices)),
-                .memory_flags = daxa::MemoryFlagBits::HOST_ACCESS_RANDOM,
-                .name = "vertex buffer",
-            });
-            defer { device.destroy_buffer(vertex_buffer); };
-            std::memcpy(device.buffer_host_address(vertex_buffer).value(), &vertices, sizeof(decltype(vertices)));
+        /// Prepare mesh data:
+        auto vertices = std::array{
+            std::array{0.25f, 0.75f, 0.5f},
+            std::array{0.5f, 0.25f, 0.5f},
+            std::array{0.75f, 0.75f, 0.5f},
+        };
+        auto vertex_buffer = device.create_buffer({
+            .size = sizeof(decltype(vertices)),
+            .memory_flags = daxa::MemoryFlagBits::HOST_ACCESS_RANDOM,
+            .name = "vertex buffer",
+        });
+        defer { device.destroy_buffer(vertex_buffer); };
+        std::memcpy(device.buffer_host_address(vertex_buffer).value(), &vertices, sizeof(decltype(vertices)));
 
-            auto indices = std::array{0, 1, 2};
-            auto index_buffer = device.create_buffer({
-                .size = sizeof(decltype(indices)),
-                .memory_flags = daxa::MemoryFlagBits::HOST_ACCESS_RANDOM,
-                .name = "index buffer",
-            });
-            defer { device.destroy_buffer(index_buffer); };
-            std::memcpy(device.buffer_host_address(index_buffer).value(), &indices, sizeof(decltype(indices)));
+        auto indices = std::array{0, 1, 2};
+        auto index_buffer = device.create_buffer({
+            .size = sizeof(decltype(indices)),
+            .memory_flags = daxa::MemoryFlagBits::HOST_ACCESS_RANDOM,
+            .name = "index buffer",
+        });
+        defer { device.destroy_buffer(index_buffer); };
+        std::memcpy(device.buffer_host_address(index_buffer).value(), &indices, sizeof(decltype(indices)));
 
-            auto transform = daxa_f32mat3x4{
-                {1, 0, 0, 0},
-                {0, 1, 0, 0},
-                {0, 0, 1, 0},
-            };
-            auto transform_buffer = device.create_buffer({
-                .size = sizeof(daxa_f32mat3x4),
-                .memory_flags = daxa::MemoryFlagBits::HOST_ACCESS_RANDOM,
-                .name = "transform buffer",
-            });
-            defer { device.destroy_buffer(transform_buffer); };
-            std::memcpy(device.buffer_host_address(transform_buffer).value(), &transform, sizeof(daxa_f32mat3x4));
+        auto transform = daxa_f32mat3x4{
+            {1, 0, 0, 0},
+            {0, 1, 0, 0},
+            {0, 0, 1, 0},
+        };
+        auto transform_buffer = device.create_buffer({
+            .size = sizeof(daxa_f32mat3x4),
+            .memory_flags = daxa::MemoryFlagBits::HOST_ACCESS_RANDOM,
+            .name = "transform buffer",
+        });
+        defer { device.destroy_buffer(transform_buffer); };
+        std::memcpy(device.buffer_host_address(transform_buffer).value(), &transform, sizeof(daxa_f32mat3x4));
 
-            // Now the geometry for the BLAS is described as a series of geometries and instances of geometries:
-            auto geometries = std::array{
-                daxa::BlasTriangleGeometryInfo{
-                    .vertex_format = daxa::Format::R32G32B32_SFLOAT,
-                    .vertex_data = device.device_address(vertex_buffer).value(),
-                    .vertex_stride = sizeof(daxa_f32vec3),
-                    .max_vertex = static_cast<u32>(vertices.size() - 1),
-                    .index_type = daxa::IndexType::uint32,
-                    .index_data = device.device_address(index_buffer).value(),
-                    .transform_data = device.device_address(transform_buffer).value(),
-                    .count = 1,
-                    .flags = {},
-                }};
-            auto build_info = daxa::BlasBuildInfo{
-                .dst_blas = {},             // Ignored in get_acceleration_structure_build_sizes, fill out later.
-                .geometries = geometries,
-                .scratch_data = {},         // Ignored in get_acceleration_structure_build_sizes, fill out later.
-            };
+        // Now the geometry for the BLAS is described as a series of geometries and instances of geometries:
+        auto geometries = std::array{
+            daxa::BlasTriangleGeometryInfo{
+                .vertex_format = daxa::Format::R32G32B32_SFLOAT,
+                .vertex_data = device.device_address(vertex_buffer).value(),
+                .vertex_stride = sizeof(daxa_f32vec3),
+                .max_vertex = static_cast<u32>(vertices.size() - 1),
+                .index_type = daxa::IndexType::uint32,
+                .index_data = device.device_address(index_buffer).value(),
+                .transform_data = device.device_address(transform_buffer).value(),
+                .count = 1,
+                .flags = {},
+            }};
+        auto build_info = daxa::BlasBuildInfo{
+            .dst_blas = {},             // Ignored in get_acceleration_structure_build_sizes, fill out later.
+            .geometries = geometries,
+            .scratch_data = {},         // Ignored in get_acceleration_structure_build_sizes, fill out later.
+        };
 
-            // Query actually needed scratch and blas buffer sizes:
-            daxa::AccelerationStructureBuildSizesInfo build_size_info = device.blas_build_sizes(build_info);
+        // Query actually needed scratch and blas buffer sizes:
+        daxa::AccelerationStructureBuildSizesInfo build_size_info = device.blas_build_sizes(build_info);
 
-            // Create scratch and blas:
-            auto scratch_buffer = device.create_buffer({
-                .size = build_size_info.build_scratch_size,
-                .name = "scratch buffer",
-            });
-            defer { device.destroy_buffer(scratch_buffer); };
-            daxa::BlasId blas = device.create_blas({
-                .size = build_size_info.acceleration_structure_size,
-                .name = "test blas",
-            });
-            defer { device.destroy_blas(blas); };
+        // Create scratch and blas:
+        auto scratch_buffer = device.create_buffer({
+            .size = build_size_info.build_scratch_size,
+            .name = "scratch buffer",
+        });
+        defer { device.destroy_buffer(scratch_buffer); };
+        daxa::BlasId blas = device.create_blas({
+            .size = build_size_info.acceleration_structure_size,
+            .name = "test blas",
+        });
+        defer { device.destroy_blas(blas); };
 
-            /// Fill the remaining fields of the build info:
-            build_info.dst_blas = blas;
-            build_info.scratch_data = device.device_address(scratch_buffer).value();
-            /// Record build commands:
-            
-            auto recorder = device.create_command_recorder({});
-            recorder.build_acceleration_structures({
-                .blas_build_infos = std::array{build_info},
-            });
-            auto exec_cmd_list = recorder.complete_current_commands();
-            device.submit_commands({.command_lists = std::array{exec_cmd_list}});
-            device.wait_idle();
-        }
-        catch (std::runtime_error error)
-        {
-            std::cout << "failed test \"acceleration_structure_creation\": " << error.what() << std::endl;
-            exit(-1);
-        }
+        /// Fill the remaining fields of the build info:
+        build_info.dst_blas = blas;
+        build_info.scratch_data = device.device_address(scratch_buffer).value();
+        /// Record build commands:
+        
+        auto recorder = device.create_command_recorder({});
+        recorder.build_acceleration_structures({
+            .blas_build_infos = std::array{build_info},
+        });
+        auto exec_cmd_list = recorder.complete_current_commands();
+        device.submit_commands({.command_lists = std::array{exec_cmd_list}});
+        device.wait_idle();
     }
 } // namespace tests
 


### PR DESCRIPTION
- `std::min` needs the type to be specified:

```
/home/ashley/projects/daxa/src/utils/impl_task_graph_ui.cpp:482:45: error: no matching function for call to ‘min(long long unsigned int, std::basic_string_view<char>::size_type)’
  482 |                 for (u32 i = 0; i < std::min(255ull, task.name.size()); ++i)
      |                                     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```

- `Imgui::Text` etc needs string literals with `-Werror=format-security` (on by default for me)

```
/home/ashley/projects/daxa/src/utils/impl_task_graph_ui.cpp:602:24: error: format not a string literal and no format arguments [-Werror=format-security]
  602 |             ImGui::Text(task.name.data());
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```

I just naïvely added "%s" everywhere, but in a lot of cases it'd probably be better to remove the `std::format` calls

- The try/catch block in 3_command_recorder was broken in https://github.com/Ipotrick/Daxa/commit/c6d57de32b09a60ec5c04e3af1886ffb76934452.