### PR TITLE
ExternalTaskImage::info() now returns is_general_layout and is_swapchain_image

### DIFF
--- a/src/utils/impl_task_graph.cpp
+++ b/src/utils/impl_task_graph.cpp
@@ -783,6 +783,8 @@ namespace daxa
         auto & impl = *r_cast<ImplExternalResource *>(this->object);
         return ExternalTaskImageInfo{
             .image = impl.id.image,
+            .is_general_layout = impl.pre_graph_is_general_layout,
+            .is_swapchain_image = impl.is_swapchain_image,
             .name = impl.name,
         };
     }
@@ -799,9 +801,8 @@ namespace daxa
 
         impl.id.image = image;
         impl.pre_graph_queue_bits = {};
-        impl.pre_graph_is_general_layout = false;
-        impl.was_presented = false;
         impl.pre_graph_is_general_layout = is_general_layout;
+        impl.was_presented = false;
     }
 
     void ExternalTaskImage::swap_images(ExternalTaskImage & other)


### PR DESCRIPTION
Noticed this when adding an `assert(external_task_image.info().is_swapchain_image);` right after using `.set_image(swapchain.acquire_next_image())`.