### PR TITLE
SurfaceFormat::color_space should default to MAX_ENUM

### DIFF
--- a/include/daxa/c/device.h
+++ b/include/daxa/c/device.h
@@ -551,7 +551,7 @@ typedef struct
 {
     daxa_NativeWindowInfo native_window_info;
     // Leave this span completely empty for daxa to select a surface format.
-    // For each preferred format, leave the color space empty for daxa to select a color space.
+    // For each preferred format, set color space to VK_COLOR_SPACE_MAX_ENUM_KHR for daxa to select it.
     daxa_SpanToConst(VkSurfaceFormatKHR) preferred_formats;
 } daxa_ChooseSwapchainSurfaceFormatInfo;
 

--- a/include/daxa/device.hpp
+++ b/include/daxa/device.hpp
@@ -535,7 +535,7 @@ namespace daxa
     {
         NativeWindowInfo native_window_info = {};
         // Leave this span completely empty for daxa to select a surface format.
-        // For each preferred format, leave the color space empty for daxa to select a color space.
+        // For each preferred format, leave the color space as MAX_ENUM for daxa to select it.
         Span<SurfaceFormat const> preferred_formats = {};
     };
 

--- a/include/daxa/swapchain.hpp
+++ b/include/daxa/swapchain.hpp
@@ -11,7 +11,7 @@ namespace daxa
     struct SurfaceFormat
     {
         Format format = {};
-        ColorSpace color_space = {};
+        ColorSpace color_space = ColorSpace::MAX_ENUM;
     };
 
     struct NativeWindowInfoWin32

--- a/src/impl_device.cpp
+++ b/src/impl_device.cpp
@@ -1936,8 +1936,9 @@ auto daxa_dvc_choose_swapchain_surface_format(
     {
         for (auto const & supported_format : supported_formats)
         {
-            bool const format_matches = supported_format.format == preferred_formats[preferred_i].format;
-            bool const color_space_matches = supported_format.colorSpace == preferred_formats[preferred_i].colorSpace || preferred_formats[preferred_i].colorSpace == VK_COLOR_SPACE_MAX_ENUM_KHR;
+            auto const & preferred_format = preferred_formats[preferred_i];
+            bool const format_matches = supported_format.format == preferred_format.format;
+            bool const color_space_matches = supported_format.colorSpace == preferred_format.colorSpace || preferred_format.colorSpace == VK_COLOR_SPACE_MAX_ENUM_KHR;
             if (format_matches && color_space_matches)
             {
                 *out_format = supported_format;


### PR DESCRIPTION
What `daxa_dvc_choose_swapchain_surface_format` does (in **impl_device.cpp**) matches the behavior of having `MAX_ENUM` as the default, _not_ `SRGB_NONLINEAR` (which is the `ColorSpace` enum's `0` value).

This would technically affect anyone directly using the C API -- as they'd now need to manually set MAX_ENUM -- but I believe everyone's going through the C++ one (so default value initialization will make this transparent).